### PR TITLE
chore: 롬복 사용 경로를 datasource 패키지로 제한

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,38 +1,60 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.0'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.0'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'kr.allcll'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('build') {
+    dependsOn('validateLombokUsage')
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
+}
+
+tasks.register('validateLombokUsage') {
+    doLast {
+        def allowedPackage = 'kr/allcll/checkll/datasource'
+        def lombokAnnotations = ['@Getter', '@Setter', '@ToString', '@AllArgsConstructor', '@NoArgsConstructor']
+
+        fileTree('src/main/java').each { file ->
+            if (file.name.endsWith('.java')) {
+                file.eachLine { line, lineNumber ->
+                    if (lombokAnnotations.any { line.contains(it) } &&
+                            !file.path.contains(allowedPackage)) {
+                        throw new GradleException("Lombok annotation found in disallowed package: ${file.path} at line ${lineNumber}")
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 구현 내용

롬복을 datasource 패키지에서만 사용할 수 있게 제한합니다. 
빌드 시점에 datasource 패키지 외에 사용하는 코드가 있는지 확인하도록 build task를 추가했습니다. 

## 논의할 사항

빌드 시점보다 컴파일 시점에 제한하는 것이 나을 것 같습니다. 
어노테이션 프로세서를 커스텀하면 가능한데, 우선순위가 높지 않습니다. 