### PR TITLE
feat: admin 기능 구현

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -34,11 +34,14 @@
 
 **HTTP method**
 
-`GET`
+`POST`
 
-~~**request**~~
-
-수동 String 생성. SetCredential호출
+**request**
+```json
+{
+    "credential": ""
+}
+```
 
 **response**
 
@@ -56,7 +59,7 @@
 
 **HTTP method**
 
-`GET`
+`POST`
 
 **request**
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -34,16 +34,11 @@
 
 **HTTP method**
 
-`POST`
+`GET`
 
-**request**
-```json
-{
-    "boye" : "",
-    "sumin" : "",
-    "juhwan" : ""
-}
-```
+~~**request**~~
+
+수동 String 생성. SetCredential호출
 
 **response**
 
@@ -61,26 +56,11 @@
 
 **HTTP method**
 
-`POST`
+`GET`
 
 **request**
-```json
-{
-    "boye" : "",
-    "sumin" : "",
-    "juhwan" : ""
-}
-```
 
 **response**
-```json
-{
-    "majorAvg": "3.88",
-    "totalAvg": "3.96",
-    "cultureAvg": "4.06",
-    "accessAt": "HHMMSS"
-}
-```
 
 **status code**
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -30,7 +30,7 @@
 
 **path**
 
-`/api/setinfo`
+`/api/set-credential`
 
 **HTTP method**
 

--- a/src/main/java/kr/allcll/checkll/api/AdminController.java
+++ b/src/main/java/kr/allcll/checkll/api/AdminController.java
@@ -29,7 +29,7 @@ public class AdminController {
 
     @GetMapping("api/end-session")
     public ResponseEntity<Void> endSession() {
-            adminService.shutDownSession();
+        adminService.shutDownSession();
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/kr/allcll/checkll/api/AdminController.java
+++ b/src/main/java/kr/allcll/checkll/api/AdminController.java
@@ -2,6 +2,7 @@ package kr.allcll.checkll.api;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,13 +15,13 @@ public class AdminController {
         this.adminService = adminService;
     }
 
-    @GetMapping("/api/set-credential")
+    @PostMapping("/api/set-credential")
     public ResponseEntity<Void> setCredential(@RequestBody SetCredentialRequest request) {
         adminService.setUpInfo(request.credential());
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/api/start-session")
+    @PostMapping("/api/start-session")
     public ResponseEntity<Void> startSession() {
         adminService.setUpSession();
         return ResponseEntity.ok().build();

--- a/src/main/java/kr/allcll/checkll/api/AdminController.java
+++ b/src/main/java/kr/allcll/checkll/api/AdminController.java
@@ -2,6 +2,7 @@ package kr.allcll.checkll.api;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -13,21 +14,21 @@ public class AdminController {
         this.adminService = adminService;
     }
 
-    @GetMapping("/api/setinfo")
-    public ResponseEntity<Void> setUpInfo() {
-        adminService.setUpInfoByString(""); //수동으로 넣나
+    @GetMapping("/api/set-credential")
+    public ResponseEntity<Void> setCredential(@RequestBody SetCredentialRequest request) {
+        adminService.setUpInfo(request.credential());
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/api/start-session")
     public ResponseEntity<Void> startSession() {
-        adminService.startInitialSession();
+        adminService.setUpSession();
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("api/end-session")
     public ResponseEntity<Void> endSession() {
-        adminService.endUpSession();
+            adminService.shutDownSession();
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/kr/allcll/checkll/api/AdminController.java
+++ b/src/main/java/kr/allcll/checkll/api/AdminController.java
@@ -1,0 +1,33 @@
+package kr.allcll.checkll.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AdminController {
+
+    private final AdminService adminService;
+
+    public AdminController(AdminService adminService) {
+        this.adminService = adminService;
+    }
+
+    @GetMapping("/api/setinfo")
+    public ResponseEntity<Void> setUpInfo() {
+        adminService.setUpInfoByString(""); //수동으로 넣나
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/api/start-session")
+    public ResponseEntity<Void> startSession() {
+        adminService.startInitialSession();
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("api/end-session")
+    public ResponseEntity<Void> endSession() {
+        adminService.endUpSession();
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/kr/allcll/checkll/api/AdminController.java
+++ b/src/main/java/kr/allcll/checkll/api/AdminController.java
@@ -17,7 +17,7 @@ public class AdminController {
 
     @PostMapping("/api/set-credential")
     public ResponseEntity<Void> setCredential(@RequestBody SetCredentialRequest request) {
-        adminService.setUpInfo(request.credential());
+        adminService.setUpCredential(request.credential());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/kr/allcll/checkll/api/AdminService.java
+++ b/src/main/java/kr/allcll/checkll/api/AdminService.java
@@ -1,0 +1,26 @@
+package kr.allcll.checkll.api;
+
+import kr.allcll.checkll.datasource.PastGradeDataSource;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AdminService {
+
+    private final PastGradeDataSource pastGradeDataSource;
+
+    public AdminService(PastGradeDataSource pastGradeDataSource) {
+        this.pastGradeDataSource = pastGradeDataSource;
+    }
+
+    public void setUpInfoByString(String credentialInfo) {
+        pastGradeDataSource.setCredential(credentialInfo);
+    }
+
+    public void startInitialSession() {
+        pastGradeDataSource.setUp();
+    }
+
+    public void endUpSession() {
+        pastGradeDataSource.shutDown();
+    }
+}

--- a/src/main/java/kr/allcll/checkll/api/AdminService.java
+++ b/src/main/java/kr/allcll/checkll/api/AdminService.java
@@ -12,15 +12,15 @@ public class AdminService {
         this.pastGradeDataSource = pastGradeDataSource;
     }
 
-    public void setUpInfoByString(String credentialInfo) {
-        pastGradeDataSource.setCredential(credentialInfo);
+    public void setUpInfo(String credential) {
+        pastGradeDataSource.setCredential(credential);
     }
 
-    public void startInitialSession() {
+    public void setUpSession() {
         pastGradeDataSource.setUp();
     }
 
-    public void endUpSession() {
+    public void shutDownSession() {
         pastGradeDataSource.shutDown();
     }
 }

--- a/src/main/java/kr/allcll/checkll/api/AdminService.java
+++ b/src/main/java/kr/allcll/checkll/api/AdminService.java
@@ -12,7 +12,7 @@ public class AdminService {
         this.pastGradeDataSource = pastGradeDataSource;
     }
 
-    public void setUpInfo(String credential) {
+    public void setUpCredential(String credential) {
         pastGradeDataSource.setCredential(credential);
     }
 

--- a/src/main/java/kr/allcll/checkll/api/PastGradeResponse.java
+++ b/src/main/java/kr/allcll/checkll/api/PastGradeResponse.java
@@ -2,17 +2,11 @@ package kr.allcll.checkll.api;
 
 import java.time.LocalDateTime;
 
-public class PastGradeResponse {
+public record PastGradeResponse(
+    String majorAvg,
+    String totalAvg,
+    String cultureAvg,
+    LocalDateTime accessAt
+) {
 
-    private final String majorAvg;
-    private final String totalAvg;
-    private final String cultureAvg;
-    private final LocalDateTime accessAt;
-
-    public PastGradeResponse(String majorAvg, String totalAvg, String cultureAvg, LocalDateTime accessAt) {
-        this.majorAvg = majorAvg;
-        this.totalAvg = totalAvg;
-        this.cultureAvg = cultureAvg;
-        this.accessAt = accessAt;
-    }
 }

--- a/src/main/java/kr/allcll/checkll/api/SetCredentialRequest.java
+++ b/src/main/java/kr/allcll/checkll/api/SetCredentialRequest.java
@@ -1,0 +1,7 @@
+package kr.allcll.checkll.api;
+
+public record SetCredentialRequest(
+    String credential
+) {
+
+}


### PR DESCRIPTION
1. Credential 설정, 요청 시작, 요청 중단 API 구현하였습니다.

2. 기존에 API 명세에서 Credential설정, 요청 시작 기능들이 POST method였는데 GET으로 수정했습니다. 외부에서 굳이 받아올 정보가 없는 것 같아서요

3. API 명세에서 response에 boye,sumin,juhwan으로 응답해주던 것들을 우선 없앴는데요...이유는 민감한 정보이기도 한데 굳이 응답으로 알려줘야하나 싶었습니다...!

4. DTO record로 바꿨어용
